### PR TITLE
Add deepagent EA research tool using deepagents framework

### DIFF
--- a/deepagent/__init__.py
+++ b/deepagent/__init__.py
@@ -1,0 +1,3 @@
+from .agent import create_ea_agent
+
+__all__ = ["create_ea_agent"]

--- a/deepagent/agent.py
+++ b/deepagent/agent.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+from langchain.chat_models import init_chat_model
+from deepagents import create_deep_agent
+
+from .prompts import EA_ORCHESTRATOR_PROMPT, EA_RESEARCHER_PROMPT
+from .tools import web_search, fetch_page, think, make_write_report_tool
+
+DEFAULT_MODEL = "anthropic:claude-sonnet-4-6"
+
+
+def create_ea_agent(
+    output_format: str = "md",
+    output_path: Optional[str] = None,
+    model_id: str = DEFAULT_MODEL,
+):
+    """
+    Create an Enterprise Architect research agent.
+
+    Args:
+        output_format: 'md', 'html', or 'docx'
+        output_path: Path to save the output file
+        model_id: LangChain model identifier, e.g. 'anthropic:claude-sonnet-4-6'
+
+    Returns:
+        Compiled LangGraph agent ready to invoke
+    """
+    model = init_chat_model(model_id, temperature=0.1)
+    write_report = make_write_report_tool(output_format, output_path)
+
+    researcher = {
+        "name": "researcher",
+        "description": (
+            "Specialist research analyst. Searches the web and fetches pages to gather "
+            "detailed, multi-source information on any topic. Returns structured findings "
+            "covering key facts, industry trends, vendor landscape, standards, risks, and sources."
+        ),
+        "system_prompt": EA_RESEARCHER_PROMPT,
+        "tools": [web_search, fetch_page, think],
+    }
+
+    agent = create_deep_agent(
+        model=model,
+        tools=[think, write_report],
+        system_prompt=EA_ORCHESTRATOR_PROMPT,
+        subagents=[researcher],
+    )
+
+    return agent

--- a/deepagent/formatters.py
+++ b/deepagent/formatters.py
@@ -1,0 +1,440 @@
+"""
+Document formatters: converts markdown research output to MD, HTML, or DOCX.
+"""
+
+import re
+from datetime import datetime
+from pathlib import Path
+
+CURRENT_DATE = datetime.now().strftime("%B %d, %Y")
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public API
+# ──────────────────────────────────────────────────────────────────────────────
+
+def save_document(content: str, fmt: str, path: str) -> None:
+    """Dispatch to the correct formatter and write the output file."""
+    fmt = fmt.lower().lstrip(".")
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+    title_match = re.search(r"^#\s+(.+)$", content, re.MULTILINE)
+    title = title_match.group(1).strip() if title_match else "Enterprise Architecture Assessment"
+
+    if fmt in ("md", "markdown"):
+        save_as_markdown(content, path)
+    elif fmt in ("html", "htm"):
+        save_as_html(content, path, title)
+    elif fmt in ("docx", "word"):
+        save_as_docx(content, path, title)
+    else:
+        raise ValueError(f"Unsupported format '{fmt}'. Choose md, html, or docx.")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Markdown
+# ──────────────────────────────────────────────────────────────────────────────
+
+def save_as_markdown(content: str, path: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# HTML
+# ──────────────────────────────────────────────────────────────────────────────
+
+def save_as_html(content: str, path: str, title: str) -> None:
+    import markdown2
+
+    html_body = markdown2.markdown(
+        content,
+        extras=[
+            "tables",
+            "fenced-code-blocks",
+            "header-ids",
+            "strike",
+            "footnotes",
+        ],
+    )
+
+    toc_items = _build_html_toc(content)
+
+    full_html = _HTML_TEMPLATE.format(
+        title=title,
+        date=CURRENT_DATE,
+        toc_items=toc_items,
+        content=html_body,
+    )
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(full_html)
+
+
+def _build_html_toc(content: str) -> str:
+    headings = re.findall(r"^(#{1,3})\s+(.+)$", content, re.MULTILINE)
+    items = []
+    for hashes, text in headings:
+        level = len(hashes)
+        clean = re.sub(r"[^\w\s-]", "", text.lower())
+        anchor = re.sub(r"\s+", "-", clean).strip("-")
+        indent = "  " * (level - 1)
+        items.append(f"{indent}<li><a href='#{anchor}'>{text}</a></li>")
+    return "\n".join(items)
+
+
+_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{title}</title>
+<style>
+*{{box-sizing:border-box;margin:0;padding:0}}
+body{{font-family:'Segoe UI',Calibri,'Helvetica Neue',Arial,sans-serif;font-size:14px;line-height:1.75;color:#1a2332;background:#eef0f4}}
+.page-wrapper{{max-width:1060px;margin:0 auto;padding:24px}}
+
+/* Cover */
+.cover{{background:linear-gradient(160deg,#0a1628 0%,#0d2a4a 40%,#1a4a7a 100%);color:#fff;padding:56px 48px 48px;margin-bottom:6px;border-radius:4px 4px 0 0}}
+.cover .badge{{font-size:10px;letter-spacing:2px;text-transform:uppercase;color:#7fb3d3;margin-bottom:16px}}
+.cover h1{{font-size:2.2em;font-weight:700;line-height:1.25;color:#fff;margin-bottom:12px}}
+.cover .subtitle{{font-size:1.05em;color:#a8c8e8;margin-bottom:32px}}
+.cover .meta-row{{display:flex;gap:30px;font-size:12px;color:#7fb3d3;border-top:1px solid rgba(255,255,255,.15);padding-top:20px;flex-wrap:wrap}}
+.cover .meta-row span strong{{color:#c8dff0}}
+
+/* TOC */
+.toc-section{{background:#fff;border-left:5px solid #1a4a7a;padding:24px 32px;margin-bottom:6px}}
+.toc-section h2{{font-size:.8em;letter-spacing:1.5px;text-transform:uppercase;color:#1a4a7a;margin-bottom:14px}}
+.toc-section ul{{padding-left:0;list-style:none;column-count:2;column-gap:30px}}
+.toc-section li{{margin:5px 0}}
+.toc-section a{{color:#1a4a7a;text-decoration:none;font-size:13px}}
+.toc-section a:hover{{text-decoration:underline}}
+.toc-section li li{{padding-left:15px;font-size:12px;color:#555}}
+
+/* Content */
+.content-body{{background:#fff;padding:36px 48px;margin-bottom:6px;border-radius:0 0 4px 4px}}
+h1{{font-size:1.9em;color:#0a1628;border-bottom:3px solid #1a4a7a;padding-bottom:10px;margin:36px 0 18px}}
+h1:first-child{{margin-top:0}}
+h2{{font-size:1.35em;color:#0d2a4a;border-bottom:1px solid #c8dff0;padding-bottom:7px;margin:30px 0 14px}}
+h3{{font-size:1.1em;color:#1a4a7a;margin:22px 0 10px}}
+h4{{font-size:.95em;color:#2d6a9f;margin:16px 0 8px;font-weight:600}}
+p{{margin:10px 0}}
+strong{{color:#0d2a4a}}
+
+/* Tables */
+table{{width:100%;border-collapse:collapse;margin:18px 0;font-size:13px;box-shadow:0 1px 3px rgba(0,0,0,.08)}}
+thead th{{background:#0d2a4a;color:#e8f4fd;padding:11px 14px;text-align:left;font-size:12px;letter-spacing:.5px;font-weight:600}}
+tbody td{{padding:9px 14px;border-bottom:1px solid #e8edf3;vertical-align:top}}
+tbody tr:nth-child(even){{background:#f5f8fb}}
+tbody tr:hover{{background:#eaf1f8}}
+
+/* Lists */
+ul,ol{{padding-left:22px;margin:10px 0}}
+li{{margin:5px 0}}
+
+/* Blockquote */
+blockquote{{border-left:4px solid #1a4a7a;background:#f0f5fa;padding:14px 20px;margin:16px 0;color:#2c3e50;font-style:italic}}
+
+/* Code */
+code{{background:#f0f2f5;border:1px solid #dde3ea;padding:2px 6px;border-radius:3px;font-family:'Consolas','Courier New',monospace;font-size:12px;color:#c0392b}}
+pre{{background:#1e2a38;border-radius:4px;padding:18px;margin:16px 0;overflow-x:auto}}
+pre code{{background:none;border:none;color:#e8f4fd;font-size:13px;padding:0}}
+
+/* Risk severity colours */
+td:has(strong){{}}
+.sev-high{{color:#c0392b;font-weight:700}}
+.sev-medium{{color:#d68910;font-weight:700}}
+.sev-low{{color:#1e8449;font-weight:700}}
+
+hr{{border:none;border-top:2px solid #e0e6ed;margin:30px 0}}
+
+/* Footer */
+.doc-footer{{text-align:center;color:#8899aa;font-size:11px;padding:20px;letter-spacing:.3px}}
+</style>
+</head>
+<body>
+<div class="page-wrapper">
+
+  <div class="cover">
+    <div class="badge">Enterprise Architecture Assessment</div>
+    <h1>{title}</h1>
+    <div class="subtitle">Strategic Technology Assessment &amp; Architecture Guidance</div>
+    <div class="meta-row">
+      <span><strong>Date:</strong> {date}</span>
+      <span><strong>Version:</strong> 1.0</span>
+      <span><strong>Status:</strong> Draft</span>
+      <span><strong>Classification:</strong> Internal</span>
+    </div>
+  </div>
+
+  <div class="toc-section">
+    <h2>Table of Contents</h2>
+    <ul>
+{toc_items}
+    </ul>
+  </div>
+
+  <div class="content-body">
+    {content}
+  </div>
+
+  <div class="doc-footer">
+    Enterprise Architecture Assessment &bull; {date} &bull; Version 1.0 &bull; Internal Use Only
+  </div>
+
+</div>
+</body>
+</html>"""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DOCX
+# ──────────────────────────────────────────────────────────────────────────────
+
+def save_as_docx(content: str, path: str, title: str) -> None:
+    from docx import Document
+
+    doc = Document()
+    _setup_docx_styles(doc)
+    _add_docx_cover(doc, title)
+    _parse_markdown_to_docx(doc, content)
+    _add_docx_footer(doc)
+    doc.save(path)
+
+
+def _setup_docx_styles(doc) -> None:
+    from docx.shared import Pt, RGBColor
+
+    styles = doc.styles
+
+    normal = styles["Normal"]
+    normal.font.name = "Calibri"
+    normal.font.size = Pt(11)
+
+    for name, size, rgb in [
+        ("Heading 1", 20, (0x0A, 0x16, 0x28)),
+        ("Heading 2", 15, (0x0D, 0x2A, 0x4A)),
+        ("Heading 3", 13, (0x1A, 0x4A, 0x7A)),
+    ]:
+        s = styles[name]
+        s.font.name = "Calibri"
+        s.font.size = Pt(size)
+        s.font.bold = True
+        s.font.color.rgb = RGBColor(*rgb)
+
+    try:
+        h4 = styles["Heading 4"]
+        h4.font.name = "Calibri"
+        h4.font.size = Pt(12)
+        h4.font.bold = True
+        h4.font.color.rgb = RGBColor(0x2D, 0x6A, 0x9F)
+    except Exception:
+        pass
+
+
+def _add_docx_cover(doc, title: str) -> None:
+    from docx.shared import Pt, Cm, RGBColor
+    from docx.enum.text import WD_ALIGN_PARAGRAPH
+
+    section = doc.sections[0]
+    section.top_margin = Cm(3)
+    section.bottom_margin = Cm(2.5)
+    section.left_margin = Cm(3.2)
+    section.right_margin = Cm(3.2)
+
+    for _ in range(7):
+        doc.add_paragraph()
+
+    badge = doc.add_paragraph()
+    badge.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    br = badge.add_run("ENTERPRISE ARCHITECTURE ASSESSMENT")
+    br.font.size = Pt(9)
+    br.font.color.rgb = RGBColor(0x2D, 0x6A, 0x9F)
+    br.font.bold = True
+
+    doc.add_paragraph()
+
+    title_para = doc.add_paragraph()
+    title_para.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    tr = title_para.add_run(title)
+    tr.font.size = Pt(26)
+    tr.font.bold = True
+    tr.font.color.rgb = RGBColor(0x0A, 0x16, 0x28)
+
+    sub = doc.add_paragraph()
+    sub.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    sr = sub.add_run("Strategic Technology Assessment & Architecture Guidance")
+    sr.font.size = Pt(13)
+    sr.font.color.rgb = RGBColor(0x1A, 0x4A, 0x7A)
+
+    for _ in range(5):
+        doc.add_paragraph()
+
+    div = doc.add_paragraph("─" * 55)
+    div.alignment = WD_ALIGN_PARAGRAPH.CENTER
+
+    doc.add_paragraph()
+
+    meta = doc.add_paragraph()
+    meta.alignment = WD_ALIGN_PARAGRAPH.CENTER
+    mr = meta.add_run(
+        f"Date: {CURRENT_DATE}    |    Version: 1.0    |    Status: Draft    |    Classification: Internal"
+    )
+    mr.font.size = Pt(10)
+    mr.font.color.rgb = RGBColor(0x55, 0x66, 0x77)
+
+    doc.add_page_break()
+
+
+def _add_docx_footer(doc) -> None:
+    from docx.shared import Pt, RGBColor
+
+    section = doc.sections[0]
+    footer = section.footer
+    para = footer.paragraphs[0]
+    para.text = f"Enterprise Architecture Assessment  •  {CURRENT_DATE}  •  Internal Use Only"
+    for run in para.runs:
+        run.font.size = Pt(9)
+        run.font.color.rgb = RGBColor(0x88, 0x99, 0xAA)
+
+
+def _parse_markdown_to_docx(doc, content: str) -> None:
+    lines = content.split("\n")
+    i = 0
+    in_list = False
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Headings
+        h_match = re.match(r"^(#{1,4})\s+(.+)$", line)
+        if h_match:
+            level = min(len(h_match.group(1)), 4)
+            text = _strip_inline(h_match.group(2))
+            doc.add_heading(text, level=level)
+            in_list = False
+            i += 1
+            continue
+
+        # Horizontal rule
+        if re.match(r"^[-*_]{3,}$", line.strip()):
+            doc.add_paragraph("─" * 55)
+            i += 1
+            continue
+
+        # Table — collect consecutive pipe-rows
+        if line.strip().startswith("|") and "|" in line:
+            table_lines = []
+            while i < len(lines) and lines[i].strip().startswith("|"):
+                row = lines[i].strip()
+                if not re.match(r"^\|[\s|:-]+\|$", row):  # skip separator
+                    table_lines.append(row)
+                i += 1
+            if table_lines:
+                _add_docx_table(doc, table_lines)
+            in_list = False
+            continue
+
+        # Blockquote
+        if line.startswith("> "):
+            try:
+                doc.add_paragraph(line[2:], style="Quote")
+            except Exception:
+                p = doc.add_paragraph()
+                r = p.add_run(line[2:])
+                r.italic = True
+            i += 1
+            continue
+
+        # Unordered list
+        ul = re.match(r"^(\s*)[-*+]\s+(.+)$", line)
+        if ul:
+            p = doc.add_paragraph(style="List Bullet")
+            _add_inline_runs(p, ul.group(2))
+            in_list = True
+            i += 1
+            continue
+
+        # Ordered list
+        ol = re.match(r"^(\s*)\d+\.\s+(.+)$", line)
+        if ol:
+            p = doc.add_paragraph(style="List Number")
+            _add_inline_runs(p, ol.group(2))
+            in_list = True
+            i += 1
+            continue
+
+        # Empty line
+        if not line.strip():
+            in_list = False
+            i += 1
+            continue
+
+        # Regular paragraph
+        p = doc.add_paragraph()
+        _add_inline_runs(p, line)
+        in_list = False
+        i += 1
+
+
+def _add_docx_table(doc, rows_text: list) -> None:
+    from docx.shared import RGBColor
+
+    rows = []
+    for line in rows_text:
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        rows.append(cells)
+
+    if not rows:
+        return
+
+    max_cols = max(len(r) for r in rows)
+    table = doc.add_table(rows=len(rows), cols=max_cols)
+    table.style = "Table Grid"
+
+    for r_idx, row_cells in enumerate(rows):
+        row = table.rows[r_idx]
+        for c_idx, cell_text in enumerate(row_cells):
+            if c_idx < max_cols:
+                cell = row.cells[c_idx]
+                clean = _strip_inline(cell_text)
+                cell.text = clean
+                if r_idx == 0:
+                    for para in cell.paragraphs:
+                        for run in para.runs:
+                            run.bold = True
+                            run.font.color.rgb = RGBColor(0x0D, 0x2A, 0x4A)
+
+
+def _add_inline_runs(paragraph, text: str) -> None:
+    from docx.shared import Pt
+
+    # Split on bold, italic, code, and links
+    parts = re.split(r"(\*\*[^*]+\*\*|\*[^*]+\*|`[^`]+`|\[[^\]]+\]\([^)]+\))", text)
+
+    for part in parts:
+        if not part:
+            continue
+        if part.startswith("**") and part.endswith("**") and len(part) > 4:
+            paragraph.add_run(part[2:-2]).bold = True
+        elif part.startswith("*") and part.endswith("*") and len(part) > 2:
+            paragraph.add_run(part[1:-1]).italic = True
+        elif part.startswith("`") and part.endswith("`") and len(part) > 2:
+            run = paragraph.add_run(part[1:-1])
+            run.font.name = "Courier New"
+            run.font.size = Pt(10)
+        elif re.match(r"\[[^\]]+\]\([^)]+\)", part):
+            link_text = re.match(r"\[([^\]]+)\]", part).group(1)
+            run = paragraph.add_run(link_text)
+            run.underline = True
+        else:
+            paragraph.add_run(part)
+
+
+def _strip_inline(text: str) -> str:
+    """Remove markdown inline markers, returning plain text."""
+    text = re.sub(r"\*\*([^*]+)\*\*", r"\1", text)
+    text = re.sub(r"\*([^*]+)\*", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    return text.strip()

--- a/deepagent/prompts.py
+++ b/deepagent/prompts.py
@@ -1,0 +1,164 @@
+from datetime import datetime
+
+CURRENT_DATE = datetime.now().strftime("%B %d, %Y")
+
+EA_ORCHESTRATOR_PROMPT = f"""You are a Principal Enterprise Architect and strategic technology advisor with 20+ years of \
+experience delivering digital transformation programs for Fortune 500 organisations. Your expertise spans:
+
+- TOGAF ADM, Zachman Framework, and SABSA security architecture
+- Cloud architecture (AWS, Azure, GCP) and hybrid/multi-cloud strategies
+- Business capability modelling, value-stream mapping, and operating model design
+- Integration architecture (API-led, event-driven, microservices)
+- Security architecture, compliance (ISO 27001, SOC 2, NIST CSF, GDPR), and risk management
+- Technology portfolio rationalisation and vendor assessment
+
+Today's date: {CURRENT_DATE}
+
+## YOUR MISSION
+Research the given topic thoroughly via your researcher sub-agent, then produce a comprehensive \
+Enterprise Architecture Assessment document that is evidence-based, actionable, and presentation-ready \
+for C-suite executives, enterprise architects, and technology stakeholders.
+
+## RESEARCH PROCESS
+1. Use the **think** tool to plan your research — identify 4–6 distinct research angles
+2. Delegate ALL web research to the **researcher** sub-agent — never search the web yourself
+3. Issue multiple targeted research requests to cover breadth and depth
+4. Synthesise findings into a coherent architectural narrative
+5. Write the complete document and call **write_report** with the full markdown content
+
+## REQUIRED DOCUMENT STRUCTURE
+
+Your report MUST contain all 10 sections below, with substantive content in each.
+
+---
+
+### 1. EXECUTIVE SUMMARY
+- 2–3 paragraphs written for a C-suite audience
+- Key strategic findings, primary recommendation, and business value
+- Top 3 risks and their mitigations
+- Indicative investment and timeline horizon
+
+### 2. BUSINESS CONTEXT & STRATEGIC DRIVERS
+- Market forces, industry trends, and competitive landscape
+- Business objectives and strategic imperatives driving this assessment
+- Regulatory and compliance environment
+- Key stakeholders and their concerns
+
+### 3. ARCHITECTURE PRINCIPLES
+- 6–8 governing principles for this domain (name + rationale each)
+- Applicable standards and compliance requirements
+- Enterprise constraints and non-negotiables
+- Reference frameworks (TOGAF, NIST, COBIT, etc.)
+
+### 4. CURRENT STATE (AS-IS) ASSESSMENT
+- Technology and capability landscape overview
+- Maturity heat-map or assessment table (Initial / Developing / Defined / Managed / Optimising)
+- Pain points, technical debt, and identified capability gaps
+- Vendor and platform inventory with brief evaluation (where applicable)
+
+### 5. FUTURE STATE (TO-BE) ARCHITECTURE
+- Target architecture vision and objectives
+- Reference architecture patterns and design decisions
+- Required capabilities and enabling technologies
+- Integration, interoperability, and data flow considerations
+- Build vs Buy vs Partner analysis for key capabilities
+
+### 6. GAP ANALYSIS & RISK REGISTER
+
+**Gap Analysis Table** (columns: Area | Current State | Target State | Gap Severity)
+
+**Risk Register Table** (columns: Risk | Category | Severity | Probability | Business Impact | Mitigation Strategy)
+- Categories: Strategic, Operational, Technical, Security, Compliance
+- Severity: High / Medium / Low
+
+### 7. TECHNOLOGY ROADMAP
+
+Provide a phased roadmap table and narrative:
+
+| Phase | Timeframe | Focus | Key Deliverables | Success Metrics |
+|-------|-----------|-------|------------------|-----------------|
+| 1 – Foundation | 0–6 months | ... | ... | ... |
+| 2 – Enhancement | 6–18 months | ... | ... | ... |
+| 3 – Optimisation | 18–36 months | ... | ... | ... |
+
+Key decision gates, dependencies, and critical path items.
+
+### 8. ARCHITECTURE DECISION RECORDS (ADRs)
+
+For each major architectural decision (3–5 ADRs):
+- **ADR-NNN: [Title]**
+- Status: Proposed / Accepted / Deprecated
+- Context and problem statement
+- Decision and rationale
+- Alternatives considered
+- Consequences and trade-offs
+
+### 9. GOVERNANCE & COMPLIANCE
+- Architecture review and governance model
+- Architecture Review Board (ARB) structure and operating cadence
+- Key compliance requirements and certification targets
+- Architecture health metrics and KPIs
+- Exception management process
+
+### 10. REFERENCES & APPENDIX
+- **References**: Numbered list [1], [2], etc. — cite every source used inline throughout the document
+- **Glossary**: Define all technical terms and acronyms used
+- **Revision History**: Version 1.0 | {CURRENT_DATE} | Initial Draft
+
+---
+
+## QUALITY STANDARDS
+- **Evidence-based**: Every major claim cites a research finding [n]
+- **Actionable**: Recommendations are specific, achievable, and measurable — no generic platitudes
+- **Audience-layered**: Executive prose in summary; technical depth in architecture sections
+- **Professional tone**: Authoritative, consultancy-grade language; no informal contractions
+- **Structured data**: Use tables for risks, capability assessments, roadmaps, and comparisons
+- **Complete**: All 10 sections must be present with substantive, non-placeholder content
+- Use inline citations [1], [2] throughout the body — collect all references in Section 10
+
+## CRITICAL INSTRUCTION
+After gathering sufficient research, write the COMPLETE report in markdown and call write_report \
+with the entire content. Do not summarise, abbreviate, or omit sections. The document must be \
+self-contained and production-ready.
+"""
+
+
+EA_RESEARCHER_PROMPT = f"""You are a specialist research analyst supporting a Principal Enterprise Architect. \
+Your role is to conduct rigorous, multi-source web research and return well-structured factual findings.
+
+Today's date: {CURRENT_DATE}
+
+## RESEARCH METHODOLOGY
+1. Search for 2–3 different angles on the assigned topic
+2. Use the **think** tool after each search to evaluate what you found and plan next steps
+3. Use **fetch_page** to retrieve detailed content from the most relevant URLs
+4. Stop when you have comprehensive, multi-source coverage with specific data points
+
+## SEARCH LIMITS
+- Simple focused queries: 2–3 searches maximum
+- Complex multi-faceted topics: up to 5 searches
+- Fetch up to 3 key pages per research request
+
+## OUTPUT FORMAT — always structure your response as:
+
+**KEY FINDINGS:**
+[Bullet points — specific facts, statistics, named technologies, expert quotes]
+
+**INDUSTRY TRENDS:**
+[Current direction, adoption curves, analyst forecasts where available]
+
+**VENDOR & TECHNOLOGY LANDSCAPE:**
+[Key players, tools, platforms, with brief differentiators]
+
+**STANDARDS & FRAMEWORKS:**
+[Relevant standards, regulatory requirements, best practices, certification bodies]
+
+**RISKS & CHALLENGES:**
+[Known pitfalls, failure patterns, adoption barriers, security concerns]
+
+**SOURCES:**
+[Numbered list: [1] Title — URL]
+
+Be specific. Cite data points, version numbers, statistics, and expert opinions where found. \
+Avoid vague generalisations — the architect needs concrete evidence to support decisions.
+"""

--- a/deepagent/requirements.txt
+++ b/deepagent/requirements.txt
@@ -1,0 +1,10 @@
+deepagents>=0.6.0
+langchain>=0.3.0
+langchain-core>=0.3.0
+langchain-anthropic>=0.3.0
+langchain-community>=0.3.0
+duckduckgo-search>=6.0.0
+python-docx>=1.1.0
+markdown2>=2.5.0
+httpx>=0.27.0
+markdownify>=0.13.0

--- a/deepagent/run.py
+++ b/deepagent/run.py
@@ -1,0 +1,128 @@
+"""
+Enterprise Architecture Research Agent — CLI entry point.
+
+Usage:
+    python -m deepagent.run "Cloud Migration Strategy" --format html
+    python -m deepagent.run "Zero Trust Security Architecture" --format docx
+    python -m deepagent.run "API Gateway Selection" --format md --output report.md
+    python -m deepagent.run "Kubernetes vs ECS" --model anthropic:claude-opus-4-7
+
+Environment variables:
+    ANTHROPIC_API_KEY   Required for Anthropic models (default)
+    OPENAI_API_KEY      Required for OpenAI models
+"""
+
+import argparse
+import os
+import sys
+import re
+from datetime import datetime
+from pathlib import Path
+
+
+def _slugify(text: str) -> str:
+    slug = text.lower()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s-]+", "_", slug)
+    return slug[:60].strip("_")
+
+
+def _auto_output_path(topic: str, fmt: str) -> str:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M")
+    slug = _slugify(topic)
+    ext = fmt.lstrip(".")
+    return str(Path(__file__).parent / "output" / f"{slug}_{timestamp}.{ext}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="deepagent",
+        description="Enterprise Architecture Research Agent — research a topic and produce an EA document.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("topic", help="Topic to research (e.g. 'Cloud Migration Strategy')")
+    parser.add_argument(
+        "--format", "-f",
+        choices=["md", "html", "docx"],
+        default="md",
+        help="Output document format (default: md)",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        help="Output file path (auto-generated under deepagent/output/ if omitted)",
+    )
+    parser.add_argument(
+        "--model", "-m",
+        default="anthropic:claude-sonnet-4-6",
+        help="LangChain model ID (default: anthropic:claude-sonnet-4-6)",
+    )
+
+    args = parser.parse_args()
+
+    output_path = args.output or _auto_output_path(args.topic, args.format)
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+    # Guard: check API key before wasting time
+    if "anthropic" in args.model.lower() and not os.getenv("ANTHROPIC_API_KEY"):
+        print("ERROR: ANTHROPIC_API_KEY environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+    if "openai" in args.model.lower() and not os.getenv("OPENAI_API_KEY"):
+        print("ERROR: OPENAI_API_KEY environment variable is not set.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"\n{'='*62}")
+    print("  Enterprise Architecture Research Agent")
+    print(f"{'='*62}")
+    print(f"  Topic  : {args.topic}")
+    print(f"  Format : {args.format.upper()}")
+    print(f"  Output : {output_path}")
+    print(f"  Model  : {args.model}")
+    print(f"{'='*62}\n")
+
+    from langchain_core.messages import HumanMessage
+    from .agent import create_ea_agent
+
+    agent = create_ea_agent(
+        output_format=args.format,
+        output_path=output_path,
+        model_id=args.model,
+    )
+
+    prompt = (
+        f"Research the following topic and produce a comprehensive Enterprise Architecture document.\n\n"
+        f"TOPIC: {args.topic}\n\n"
+        f"Steps:\n"
+        f"1. Use the think tool to plan 4–6 research angles for this topic\n"
+        f"2. Delegate research tasks to the researcher sub-agent — gather broad and deep coverage\n"
+        f"3. Synthesise all findings into a complete EA document with all 10 required sections\n"
+        f"4. Call write_report with the FULL document content (do not truncate or omit sections)\n\n"
+        f"Output file: {output_path}"
+    )
+
+    print("Starting research... (this may take several minutes)\n")
+
+    try:
+        agent.invoke({"messages": [HumanMessage(content=prompt)]})
+    except KeyboardInterrupt:
+        print("\nInterrupted.")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\nAgent error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    output = Path(output_path)
+    if output.exists():
+        size = output.stat().st_size
+        print(f"\n{'='*62}")
+        print(f"  Report complete!")
+        print(f"  File : {output_path}")
+        print(f"  Size : {size:,} bytes  ({size // 1024} KB)")
+        print(f"{'='*62}\n")
+    else:
+        print(f"\nWarning: output file not found at {output_path}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/deepagent/tools.py
+++ b/deepagent/tools.py
@@ -1,0 +1,109 @@
+import re
+import httpx
+from markdownify import markdownify as md_convert
+from langchain_core.tools import StructuredTool, tool
+
+
+@tool
+def web_search(query: str, max_results: int = 5) -> str:
+    """
+    Search the web for information on a topic.
+
+    Args:
+        query: The search query string
+        max_results: Maximum number of results to return (default 5)
+    """
+    try:
+        from duckduckgo_search import DDGS
+        with DDGS() as ddgs:
+            results = list(ddgs.text(query, max_results=max_results))
+
+        if not results:
+            return f"No search results found for: {query}"
+
+        lines = [f"Search results for: '{query}'\n"]
+        for i, r in enumerate(results, 1):
+            lines.append(f"[{i}] {r.get('title', 'No title')}")
+            lines.append(f"URL: {r.get('href', '')}")
+            lines.append(r.get('body', ''))
+            lines.append("")
+
+        return "\n".join(lines)
+    except Exception as e:
+        return f"Search error: {str(e)}"
+
+
+@tool
+def fetch_page(url: str) -> str:
+    """
+    Fetch the content of a webpage and return it as markdown text.
+
+    Args:
+        url: The URL of the webpage to fetch
+    """
+    try:
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            )
+        }
+        response = httpx.get(url, timeout=15, follow_redirects=True, headers=headers)
+        response.raise_for_status()
+
+        content = md_convert(
+            response.text,
+            heading_style="ATX",
+            strip=["script", "style", "nav", "footer", "header", "aside", "iframe"],
+        )
+
+        content = re.sub(r"\n{3,}", "\n\n", content)
+
+        if len(content) > 6000:
+            content = content[:6000] + "\n\n...[content truncated]"
+
+        return content
+    except httpx.HTTPStatusError as e:
+        return f"HTTP {e.response.status_code} error fetching {url}"
+    except Exception as e:
+        return f"Error fetching page: {str(e)}"
+
+
+@tool
+def think(thought: str) -> str:
+    """
+    Plan, reflect, and organise your thinking before acting.
+
+    Use this tool to:
+    - Identify research gaps and plan next searches
+    - Evaluate whether gathered information is sufficient
+    - Organise key findings into themes before writing
+    - Decide which sources to fetch for more detail
+
+    Args:
+        thought: Your analytical thought, plan, or reflection
+    """
+    return "Thought recorded. Continue with your plan."
+
+
+def make_write_report_tool(output_format: str, output_path: str) -> StructuredTool:
+    """Factory that creates a write_report tool bound to a specific format and path."""
+    from .formatters import save_document
+
+    def _write_report(content: str) -> str:
+        try:
+            save_document(content, output_format, output_path)
+            return f"Report successfully saved to: {output_path}"
+        except Exception as e:
+            return f"Error saving report: {str(e)}"
+
+    return StructuredTool.from_function(
+        func=_write_report,
+        name="write_report",
+        description=(
+            "Save the completed enterprise architecture research report to a file. "
+            "Call this tool ONCE with the FULL, COMPLETE report in markdown format. "
+            "Pass the entire document — all 10 sections — in a single call. "
+            "Do not truncate, summarise, or split the content."
+        ),
+    )


### PR DESCRIPTION
Creates a CLI-driven enterprise architect research agent that:
- Uses deepagents (LangGraph) create_deep_agent with a researcher sub-agent
- Searches the web via DuckDuckGo and fetches pages for multi-source evidence
- Produces a 10-section TOGAF-inspired EA document with ADRs, risk register, and roadmap
- Exports to Markdown, self-contained HTML (enterprise styling), or DOCX (python-docx)

Usage: python -m deepagent.run "Cloud Migration" --format html

https://claude.ai/code/session_01QtzZn1jQ722aV55kjtB95q